### PR TITLE
Make the frame buffer size to 2:1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,6 +45,7 @@
         "stdlib.h": "c",
         "clocks.h": "c",
         "draw_text.h": "c",
-        "cstdint": "c"
+        "cstdint": "c",
+        "hardware_interface.h": "c"
     }
 }

--- a/include/draw.h
+++ b/include/draw.h
@@ -15,9 +15,9 @@
 #define COLOR_CYAN 0x1F
 #define COLOR_MAGENTA 0xE3
 
-void draw_background(uint8_t *buffer, int buffer_width, int buffer_height, int color);
-void draw_rect(uint8_t *buffer, int buffer_width, int buffer_height, int x, int y, int width, int height, int color);
-void draw_text(uint8_t *buffer, int buffer_width, int buffer_height, int x, int y, const char *text, int color);
-void draw_text_fast(uint8_t *buffer, int buffer_width, int buffer_height, int x, int y, const char *text, int color);
+void draw_background(uint8_t *buffer, int color);
+void draw_rect(uint8_t *buffer, int x, int y, int width, int height, int color);
+void draw_text(uint8_t *buffer, int x, int y, const char *text, int color);
+void draw_text_fast(uint8_t *buffer, int x, int y, const char *text, int color);
 
 #endif

--- a/include/framebuffer.h
+++ b/include/framebuffer.h
@@ -9,8 +9,11 @@
 // Display resolution configuration
 #define FRAMEBUFFER_WIDTH 640  // Internal buffer width
 #define FRAMEBUFFER_HEIGHT 240 // Internal buffer height
-#define DISPLAY_WIDTH 640       // Display width (2x scale)
-#define DISPLAY_HEIGHT 480      // Display height (2x scale)
+#define DISPLAY_WIDTH 640      // Display width (2x scale)
+#define DISPLAY_HEIGHT 480     // Display height (2x scale)
+
+#define FRAMEBUFFER_PIXEL_WIDTH 2  // Pixel width in the framebuffer
+#define FRAMEBUFFER_PIXEL_HEIGHT 1 // Pixel height in the framebuffer (1:2 vertical scale on display)
 
 // Frame buffer structure
 typedef struct

--- a/include/framebuffer.h
+++ b/include/framebuffer.h
@@ -7,22 +7,25 @@
 #include "dvi_defines.h"
 
 // Display resolution configuration
-#define FRAMEBUFFER_WIDTH 320 // Internal buffer width
+#define FRAMEBUFFER_WIDTH 640  // Internal buffer width
 #define FRAMEBUFFER_HEIGHT 240 // Internal buffer height
-#define OUTPUT_WIDTH 640 // DVI output width (2x scale)
-#define OUTPUT_HEIGHT 480 // DVI output height (2x scale)
+#define DISPLAY_WIDTH 640       // Display width (2x scale)
+#define DISPLAY_HEIGHT 480      // Display height (2x scale)
 
 // Frame buffer structure
-typedef struct {
-    volatile uint8_t current_display_buffer;                     // Index of the currently displayed buffer (0 or 1)
+typedef struct
+{
+    volatile uint8_t current_display_buffer; // Index of the currently displayed buffer (0 or 1)
 } framebuffer_t;
 
 // FIFO message structure (packed into 32 bits)
-typedef union {
-    struct {
+typedef union
+{
+    struct
+    {
         uint8_t buffer_index; // Index into the line data buffers array
     };
-    uint32_t raw;              // Raw 32-bit value for FIFO transfer
+    uint32_t raw; // Raw 32-bit value for FIFO transfer
 } fifo_msg_t;
 
 // Initialize frame buffer
@@ -47,6 +50,6 @@ bool framebuffer_swap(void);
 bool framebuffer_wait_ready(void);
 
 // Get a scaled scanline for DVI output
-void frame_buffer_get_scaled_line(uint8_t* line_buffer, uint32_t line);
+void framebuffer_get_line(uint8_t *line_buffer, uint32_t line);
 
 #endif // FRAME_BUFFER_H

--- a/mrbgems/mruby-picorabbit-draw/src/picorabbit_draw.c
+++ b/mrbgems/mruby-picorabbit-draw/src/picorabbit_draw.c
@@ -2,6 +2,7 @@
 #include <mruby.h>
 #include <mruby/string.h>
 
+#include "../../../include/framebuffer.h"
 #include "../../../include/draw.h"
 
 static mrb_value

--- a/mrbgems/mruby-picorabbit-draw/src/picorabbit_draw.c
+++ b/mrbgems/mruby-picorabbit-draw/src/picorabbit_draw.c
@@ -2,7 +2,6 @@
 #include <mruby.h>
 #include <mruby/string.h>
 
-#include "../../../include/framebuffer.h"
 #include "../../../include/draw.h"
 
 static mrb_value
@@ -11,7 +10,7 @@ mrb_background(mrb_state *mrb, mrb_value self)
     mrb_int color;
     mrb_get_args(mrb, "i", &color);
 
-    draw_background(framebuffer_get_draw(), FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, color);
+    draw_background(framebuffer_get_draw(), color);
 
     return mrb_nil_value();
 }
@@ -22,7 +21,7 @@ mrb_draw_rect(mrb_state *mrb, mrb_value self)
     mrb_int x, y, width, height, color;
     mrb_get_args(mrb, "iiii", &x, &y, &width, &height, &color);
 
-    draw_rect(framebuffer_get_draw(), FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, x, y, width, height, color);
+    draw_rect(framebuffer_get_draw(), x, y, width, height, color);
 
     return mrb_nil_value();
 }
@@ -37,7 +36,7 @@ mrb_draw_text_with_color(mrb_state *mrb, mrb_value self)
 
     uint8_t *buffer = framebuffer_get_draw();
 
-    draw_text(buffer, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, x, y, mrb_string_value_cstr(mrb, &str), color);
+    draw_text(buffer, x, y, mrb_string_value_cstr(mrb, &str), color);
 
     return mrb_nil_value();
 }
@@ -49,8 +48,7 @@ mrb_commit(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
 }
 
-void
-mrb_mruby_picorabbit_draw_gem_init(mrb_state *mrb)
+void mrb_mruby_picorabbit_draw_gem_init(mrb_state *mrb)
 {
     struct RClass *module_picorabbit = mrb_define_module(mrb, "PicoRabbit");
     struct RClass *module_draw = mrb_define_module_under(mrb, module_picorabbit, "Draw");
@@ -60,9 +58,6 @@ mrb_mruby_picorabbit_draw_gem_init(mrb_state *mrb)
     mrb_define_module_function(mrb, module_draw, "draw_text", mrb_draw_text_with_color, MRB_ARGS_REQ(4));
 
     mrb_define_module_function(mrb, module_draw, "commit", mrb_commit, MRB_ARGS_NONE());
-
-
 }
 
-void
-mrb_mruby_picorabbit_draw_gem_final(mrb_state *mrb) {}
+void mrb_mruby_picorabbit_draw_gem_final(mrb_state *mrb) {}

--- a/mrbgems/mruby-picorabbit/test/picorabbit_test.rb
+++ b/mrbgems/mruby-picorabbit/test/picorabbit_test.rb
@@ -7,4 +7,3 @@ assert('PicoRabbit::draw_slide') do
   val = TextBuf.get(2, 5)
   assert_equal '*'.ord | (6 << 8), val
 end
-  

--- a/src/draw.c
+++ b/src/draw.c
@@ -32,6 +32,9 @@ void draw_rect(uint8_t *buffer, int x, int y, int width, int height, int color)
 // Draw text line
 void draw_text(uint8_t *buffer, int x, int y, const char *text, int color)
 {
+    x *= FRAMEBUFFER_PIXEL_WIDTH;
+    y *= FRAMEBUFFER_PIXEL_HEIGHT;
+
     if (y + FONT_HEIGHT <= 0 || y >= FRAMEBUFFER_HEIGHT || x >= FRAMEBUFFER_WIDTH)
     {
         return;
@@ -57,13 +60,14 @@ void draw_text(uint8_t *buffer, int x, int y, const char *text, int color)
             uint8_t bits = glyph[j];
             for (int i = 0; i < FONT_WIDTH; i++)
             {
-                int px = char_x + i;
+                int px = (char_x + i) * FRAMEBUFFER_PIXEL_WIDTH;
                 if (px < 0 || px >= FRAMEBUFFER_WIDTH)
                     continue;
 
                 if (bits & (1 << i))
                 {
                     buffer[py * FRAMEBUFFER_WIDTH + px] = color;
+                    buffer[py * FRAMEBUFFER_WIDTH + px + 1] = color;
                 }
             }
         }

--- a/src/draw.c
+++ b/src/draw.c
@@ -2,53 +2,68 @@
 #include <string.h>
 
 #include "draw.h"
+#include "framebuffer.h"
 
 #include "../vendor/font8x8/font8x8_basic.h"
 
 // Draw background
-void draw_background(uint8_t *buffer, int width, int height, int color) {
-    memset(buffer, color, width * height);
+void draw_background(uint8_t *buffer, int color)
+{
+    memset(buffer, color, FRAMEBUFFER_WIDTH * FRAMEBUFFER_HEIGHT);
 }
 
 // Draw rectangle
-void draw_rect(uint8_t *buffer, int buffer_width, int buffer_height, int x, int y, int width, int height, int color) {
+void draw_rect(uint8_t *buffer, int x, int y, int width, int height, int color)
+{
     // Boundary check
-    if (x < 0 || y < 0 || x >= buffer_width || y >= buffer_height) {
+    if (x < 0 || y < 0 || x >= FRAMEBUFFER_WIDTH || y >= FRAMEBUFFER_HEIGHT)
+    {
         return;
     }
 
-    int draw_width = (x + width > buffer_width) ? buffer_width - x : width;
-    int draw_height = (y + height > buffer_height) ? buffer_height - y : height;
-    for (int j = 0; j < draw_height; j++) {
-        memset(&buffer[(y + j) * buffer_width + x], color, draw_width);
+    int draw_width = (x + width > FRAMEBUFFER_WIDTH) ? FRAMEBUFFER_WIDTH - x : width;
+    int draw_height = (y + height > FRAMEBUFFER_HEIGHT) ? FRAMEBUFFER_HEIGHT - y : height;
+    for (int j = 0; j < draw_height; j++)
+    {
+        memset(&buffer[(y + j) * FRAMEBUFFER_WIDTH + x], color, draw_width);
     }
 }
 
 // Draw text line
-void draw_text(uint8_t *buffer, int width, int height, int x, int y, const char *text, int color) {
-    if (y + FONT_HEIGHT <= 0 || y >= height || x >= width) {
+void draw_text(uint8_t *buffer, int x, int y, const char *text, int color)
+{
+    if (y + FONT_HEIGHT <= 0 || y >= FRAMEBUFFER_HEIGHT || x >= FRAMEBUFFER_WIDTH)
+    {
         return;
     }
 
-    for (int t = 0; text[t] != '\0'; t++) {
+    for (int t = 0; text[t] != '\0'; t++)
+    {
         unsigned char c = (unsigned char)text[t];
         const uint8_t *glyph = font8x8_basic[c];
-        if (!glyph) continue;
+        if (!glyph)
+            continue;
 
         int char_x = x + t * FONT_WIDTH;
-        if (char_x + FONT_WIDTH <= 0 || char_x >= width) continue;
+        if (char_x + FONT_WIDTH <= 0 || char_x >= FRAMEBUFFER_WIDTH)
+            continue;
 
-        for (int j = 0; j < FONT_HEIGHT; j++) {
+        for (int j = 0; j < FONT_HEIGHT; j++)
+        {
             int py = y + j;
-            if (py < 0 || py >= height) continue;
+            if (py < 0 || py >= FRAMEBUFFER_HEIGHT)
+                continue;
 
             uint8_t bits = glyph[j];
-            for (int i = 0; i < FONT_WIDTH; i++) {
+            for (int i = 0; i < FONT_WIDTH; i++)
+            {
                 int px = char_x + i;
-                if (px < 0 || px >= width) continue;
+                if (px < 0 || px >= FRAMEBUFFER_WIDTH)
+                    continue;
 
-                if (bits & (1 << i)) {
-                    buffer[py * width + px] = color;
+                if (bits & (1 << i))
+                {
+                    buffer[py * FRAMEBUFFER_WIDTH + px] = color;
                 }
             }
         }
@@ -56,17 +71,22 @@ void draw_text(uint8_t *buffer, int width, int height, int x, int y, const char 
 }
 
 // Draw text line faster (skips coordinate checks)
-void draw_text_fast(uint8_t *buffer, int width, int height, int x, int y, const char *text, int color) {
-    for (int i = 0; text[i] != '\0'; i++) {
+void draw_text_fast(uint8_t *buffer, int x, int y, const char *text, int color)
+{
+    for (int i = 0; text[i] != '\0'; i++)
+    {
         const uint8_t *glyph = (uint8_t *)font8x8_basic[(uint8_t)text[i]];
         int base_x = x + i * FONT_WIDTH;
 
-        for (int dy = 0; dy < FONT_HEIGHT; dy++) {
+        for (int dy = 0; dy < FONT_HEIGHT; dy++)
+        {
             uint8_t bits = glyph[dy];
-            uint8_t *dst = &buffer[(y + dy) * width + base_x];
+            uint8_t *dst = &buffer[(y + dy) * FRAMEBUFFER_WIDTH + base_x];
 
-            for (int dx = 0; dx < FONT_WIDTH; dx++) {
-                if (bits & (1 << dx)) {
+            for (int dx = 0; dx < FONT_WIDTH; dx++)
+            {
+                if (bits & (1 << dx))
+                {
                     dst[dx] = color;
                 }
             }

--- a/src/framebuffer.c
+++ b/src/framebuffer.c
@@ -8,21 +8,10 @@
 #define CORE_READY_FLAG 123
 
 static framebuffer_t framebuffer;
-static uint8_t line_buffer_half[FRAMEBUFFER_WIDTH];
 static uint8_t framebuffer_buffers[2][FRAMEBUFFER_WIDTH * FRAMEBUFFER_HEIGHT];
 
-static uint16_t expand_table[256];
-
-static void init_expand_table(void) {
-    for (int c = 0; c < 256; c++) {
-        expand_table[c] = (uint16_t)((c << 8) | c);
-    }
-}
-
-
-void framebuffer_init(void) {
-    init_expand_table();
-
+void framebuffer_init(void)
+{
     memset(&framebuffer, 0, sizeof(framebuffer));
     draw_background(framebuffer_buffers[0], FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, COLOR_WHITE);
     draw_background(framebuffer_buffers[1], FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, COLOR_WHITE);
@@ -33,52 +22,58 @@ void framebuffer_init(void) {
     printf("framebuffer initialized width=%d height=%d\n", FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT);
 }
 
-void framebuffer_deinit(void) {
+void framebuffer_deinit(void)
+{
     // Nothing to do
 }
 
-const uint8_t *framebuffer_get_display(void) {
+const uint8_t *framebuffer_get_display(void)
+{
     return (uint8_t *)&framebuffer_buffers[framebuffer.current_display_buffer];
 }
 
-uint8_t *framebuffer_get_draw(void) {
+uint8_t *framebuffer_get_draw(void)
+{
     return (uint8_t *)&framebuffer_buffers[!framebuffer.current_display_buffer];
 }
 
-void framebuffer_commit(void) {
+void framebuffer_commit(void)
+{
     fifo_msg_t msg = {
         .buffer_index = !framebuffer.current_display_buffer // back buffer
     };
     multicore_fifo_push_blocking(msg.raw);
 }
 
-void frame_buffer_get_scaled_line(uint8_t* line_buffer, uint32_t line) {
+void framebuffer_get_line(uint8_t *line_buffer, uint32_t line)
+{
     uint16_t *dst = (uint16_t *)line_buffer;
-    const uint8_t* src = framebuffer_buffers[framebuffer.current_display_buffer];
-    for (int x = 0; x < FRAMEBUFFER_WIDTH; x++) {
-        uint8_t c = src[line / 2 * FRAMEBUFFER_WIDTH + x];
-        dst[x] = expand_table[c];
-    }
+    // The framebuffer size is the half the screen size vertically.
+    const uint8_t *src = &framebuffer_buffers[framebuffer.current_display_buffer][(line / 2) * FRAMEBUFFER_WIDTH];
+    memcpy(line_buffer, src, FRAMEBUFFER_WIDTH);
 }
 
 // Wait for the next framebuffer to be committed
-bool framebuffer_wait_ready(void) {
+bool framebuffer_wait_ready(void)
+{
     uint32_t flag = multicore_fifo_pop_blocking();
     return flag == CORE_READY_FLAG;
 }
 
 // Swap the front and back buffers
-bool framebuffer_swap(void) {
+bool framebuffer_swap(void)
+{
     // Check if there is new data in the FIFO
-    if (multicore_fifo_rvalid()) {
+    if (multicore_fifo_rvalid())
+    {
         uint32_t raw = multicore_fifo_pop_blocking();
-        fifo_msg_t msg = { .raw = raw };
+        fifo_msg_t msg = {.raw = raw};
 
-        if (msg.buffer_index != framebuffer.current_display_buffer) {
+        if (msg.buffer_index != framebuffer.current_display_buffer)
+        {
             framebuffer.current_display_buffer = msg.buffer_index;
             return true;
         }
     }
     return false;
 }
-

--- a/src/framebuffer.c
+++ b/src/framebuffer.c
@@ -13,8 +13,8 @@ static uint8_t framebuffer_buffers[2][FRAMEBUFFER_WIDTH * FRAMEBUFFER_HEIGHT];
 void framebuffer_init(void)
 {
     memset(&framebuffer, 0, sizeof(framebuffer));
-    draw_background(framebuffer_buffers[0], FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, COLOR_WHITE);
-    draw_background(framebuffer_buffers[1], FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, COLOR_WHITE);
+    draw_background(framebuffer_buffers[0], COLOR_WHITE);
+    draw_background(framebuffer_buffers[1], COLOR_WHITE);
 
     framebuffer.current_display_buffer = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,8 @@
 #include "main_task.h"
 
 // Core 1: DVI output and line buffer management
-void core1_main() {
+void core1_main()
+{
     init_clock();
     sleep_ms(500);
     framebuffer_init();
@@ -25,14 +26,16 @@ void core1_main() {
 }
 
 // Core 0: Line generation and LED control
-void core0_main() {
+void core0_main()
+{
     const uint LED_PIN = PICO_DEFAULT_LED_PIN;
     gpio_init(LED_PIN);
     gpio_set_dir(LED_PIN, GPIO_OUT);
 
     // Initialize mruby VM
     mrb_state *mrb = mrb_open();
-    if (!mrb) {
+    if (!mrb)
+    {
         printf("Failed to open mrb\n");
         return;
     }
@@ -44,7 +47,8 @@ void core0_main() {
     mrb_sym method = mrb_intern_lit(mrb, "render");
 
     // Wait for line buffer to be ready
-    while (!framebuffer_wait_ready()) {
+    while (!framebuffer_wait_ready())
+    {
         tight_loop_contents();
     }
     printf("framebuffer ready\n");
@@ -55,23 +59,25 @@ void core0_main() {
 
     // Load main task first to define the render function
     mrb_value ret = mrb_load_irep(mrb, main_task);
-    if (mrb->exc) {
+    if (mrb->exc)
+    {
         printf("mruby execution failed:\n");
         mrb_print_error(mrb);
-    }
-
-    // Draw red screen
-    while (true) {
-        uint8_t* back_buffer = framebuffer_get_draw();
-        draw_background(back_buffer, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, COLOR_RED);
-        draw_text(back_buffer, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, 0, 8, "mruby execution failed!", COLOR_WHITE);
-        framebuffer_commit();
+        while (true)
+        {
+            uint8_t *back_buffer = framebuffer_get_draw();
+            draw_background(back_buffer, COLOR_RED);
+            draw_text(back_buffer, 0, 8, "mruby execution failed!", COLOR_WHITE);
+            framebuffer_commit();
+            tight_loop_contents();
+        }
     }
 
     mrb_close(mrb);
 }
 
-int main() {
+int main()
+{
     // Configure voltage for high-speed operation
     vreg_set_voltage(VREG_VOLTAGE_1_30);
     sleep_ms(100);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.13)
+
 # 共通のソースファイル
 set(TEST_SOURCES
     main.c

--- a/tests/main.c
+++ b/tests/main.c
@@ -8,20 +8,18 @@ void test_draw_background(void);
 void test_draw_rect(void);
 void test_draw_text(void);
 void test_draw_text_fast(void);
+void run_draw_tests(void);
 void run_framebuffer_tests(void);
 
 int main() {
-    printf("Starting tests...\n");
+    printf("= Starting tests...\n");
 
     // Hardware initialization
     hw_init();
 
-    test_draw_background();
-    test_draw_rect();
-    test_draw_text();
-    test_draw_text_fast();
+    run_draw_tests();
     run_framebuffer_tests();
 
-    printf("All tests passed successfully!\n");
+    printf("= All tests passed successfully!\n");
     return 0;
 }

--- a/tests/mocks/hardware_mock.c
+++ b/tests/mocks/hardware_mock.c
@@ -1,5 +1,6 @@
 #ifdef PICO_DESKTOP_TEST
 
+#include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
 
@@ -17,6 +18,7 @@ static int fifo_write_pos = 0;
 
 void hw_init(void) {
     memset(display_buffer, 0, BUFFER_SIZE);
+    memset(fifo_buffer, 0, sizeof(fifo_buffer));
     fifo_read_pos = 0;
     fifo_write_pos = 0;
 }
@@ -33,16 +35,23 @@ void hw_update_display(void) {
 void multicore_fifo_push_blocking(uint32_t data) {
     fifo_buffer[fifo_write_pos] = data;
     fifo_write_pos = (fifo_write_pos + 1) % 16;
+    printf("+ (mock) multicore_fifo_push_blocking: %d\n", data);
 }
 
 uint32_t multicore_fifo_pop_blocking(void) {
     uint32_t data = fifo_buffer[fifo_read_pos];
     fifo_read_pos = (fifo_read_pos + 1) % 16;
+    printf("+ (mock) multicore_fifo_pop_blocking: %d\n", data);
     return data;
 }
 
 bool multicore_fifo_rvalid(void) {
-    return fifo_read_pos != fifo_write_pos;
+    if (fifo_read_pos != fifo_write_pos) {
+        printf("+ (mock) multicore_fifo_rvalid: true\n");
+        return true;
+    }
+    printf("+ (mock) multicore_fifo_rvalid: false\n");
+    return false;
 }
 
 uint32_t get_core_num(void) {

--- a/tests/test_draw.c
+++ b/tests/test_draw.c
@@ -100,3 +100,25 @@ void test_draw_text_fast(void) {
     }
     assert(!assert_failed);
 }
+
+void run_draw_tests(void) {
+    printf("== run_draw_tests\n");
+
+    printf("=== ↓ test_draw_background\n");
+    test_draw_background();
+    printf("=== ↑ test_draw_background ........... OK\n");
+
+    printf("=== ↓ test_draw_rect\n");
+    test_draw_rect();
+    printf("=== ↑ test_draw_rect ................. OK\n");
+
+    printf("=== ↓ test_draw_text\n");
+    test_draw_text();
+    printf("=== ↑ test_draw_text ................. OK\n");
+
+    printf("=== ↓ test_draw_text_fast\n");
+    test_draw_text_fast();
+    printf("=== ↑ test_draw_text_fast ............ OK\n");
+
+    printf("== run_draw_tests .................... OK\n");
+}


### PR DESCRIPTION
The problem is the buffer scaling in the DVI output handler function.
It causes the delays and make broken output.

To fix this problem, I make buffer scaling ratio to 1:2, to remove the scaling loop in the DVI output handler.
Thus, the buffers have full width and half the height of the output size.
Memory usage with double buffering matchies the display size (640 x 480 = 307,200B)